### PR TITLE
Move all java class to tech.ydb.proto

### DIFF
--- a/draft/protos/ydb_maintenance.proto
+++ b/draft/protos/ydb_maintenance.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 option cc_enable_arenas = true;
 
 package Ydb.Maintenance;
-option java_package = "tech.ydb.draft.maintenance.v1";
+option java_package = "tech.ydb.proto.draft.maintenance.v1";
 option go_package = "github.com/ydb-platform/ydb-go-genproto/draft/protos/Ydb_Maintenance";
 
 import "protos/ydb_status_codes.proto";

--- a/draft/protos/ydb_query.proto
+++ b/draft/protos/ydb_query.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 option cc_enable_arenas = true;
 
 package Ydb.Query;
-option java_package = "tech.ydb.draft.query";
+option java_package = "tech.ydb.proto.draft.query";
 option go_package = "github.com/ydb-platform/ydb-go-genproto/draft/protos/Ydb_Query";
 
 import "protos/annotations/validation.proto";

--- a/draft/ydb_maintenance_v1.proto
+++ b/draft/ydb_maintenance_v1.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 
 package Ydb.Maintenance.V1;
-option java_package = "tech.ydb.draft.maintenance";
+option java_package = "tech.ydb.proto.draft.maintenance";
 option go_package = "github.com/ydb-platform/ydb-go-genproto/draft/Ydb_Maintenance_V1";
 
 import "draft/protos/ydb_maintenance.proto";

--- a/draft/ydb_query_v1.proto
+++ b/draft/ydb_query_v1.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 
 package Ydb.Query.V1;
-option java_package = "tech.ydb.draft.query.v1";
+option java_package = "tech.ydb.proto.draft.query.v1";
 option go_package = "github.com/ydb-platform/ydb-go-genproto/draft/Ydb_Query_V1";
 
 import "draft/protos/ydb_query.proto";

--- a/protos/annotations/validation.proto
+++ b/protos/annotations/validation.proto
@@ -4,7 +4,7 @@ option cc_enable_arenas = true;
 package Ydb;
 
 option go_package = "github.com/ydb-platform/ydb-go-genproto/protos/Ydb";
-option java_package = "tech.ydb";
+option java_package = "tech.ydb.proto";
 
 import "google/protobuf/descriptor.proto";
 

--- a/protos/ydb_auth.proto
+++ b/protos/ydb_auth.proto
@@ -4,7 +4,7 @@ option cc_enable_arenas = true;
 package Ydb.Auth;
 
 option go_package = "github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Auth";
-option java_package = "tech.ydb.auth";
+option java_package = "tech.ydb.proto.auth";
 
 import "protos/ydb_operation.proto";
 

--- a/protos/ydb_cms.proto
+++ b/protos/ydb_cms.proto
@@ -4,7 +4,7 @@ option cc_enable_arenas = true;
 package Ydb.Cms;
 
 option go_package = "github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Cms";
-option java_package = "tech.ydb.cms";
+option java_package = "tech.ydb.proto.cms";
 
 import "protos/ydb_operation.proto";
 

--- a/protos/ydb_common.proto
+++ b/protos/ydb_common.proto
@@ -4,7 +4,7 @@ option cc_enable_arenas = true;
 package Ydb;
 
 option go_package = "github.com/ydb-platform/ydb-go-genproto/protos/Ydb";
-option java_package = "tech.ydb.common";
+option java_package = "tech.ydb.proto.common";
 option java_outer_classname = "CommonProtos";
 
 message FeatureFlag {

--- a/protos/ydb_coordination.proto
+++ b/protos/ydb_coordination.proto
@@ -4,7 +4,7 @@ option cc_enable_arenas = true;
 package Ydb.Coordination;
 
 option go_package = "github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Coordination";
-option java_package = "tech.ydb.coordination";
+option java_package = "tech.ydb.proto.coordination";
 option java_outer_classname = "CoordinationProtos";
 option java_multiple_files = true;
 

--- a/protos/ydb_discovery.proto
+++ b/protos/ydb_discovery.proto
@@ -4,7 +4,7 @@ option cc_enable_arenas = true;
 package Ydb.Discovery;
 
 option go_package = "github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Discovery";
-option java_package = "tech.ydb.discovery";
+option java_package = "tech.ydb.proto.discovery";
 option java_outer_classname = "DiscoveryProtos";
 
 import "protos/ydb_operation.proto";

--- a/protos/ydb_export.proto
+++ b/protos/ydb_export.proto
@@ -9,7 +9,7 @@ import "google/protobuf/timestamp.proto";
 package Ydb.Export;
 
 option go_package = "github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Export";
-option java_package = "tech.ydb.export";
+option java_package = "tech.ydb.proto.export";
 
 /// Common
 message ExportProgress {

--- a/protos/ydb_federation_discovery.proto
+++ b/protos/ydb_federation_discovery.proto
@@ -4,7 +4,7 @@ option cc_enable_arenas = true;
 package Ydb.FederationDiscovery;
 
 option go_package = "github.com/ydb-platform/ydb-go-genproto/protos/Ydb_FederationDiscovery";
-option java_package = "tech.ydb.federation.discovery";
+option java_package = "tech.ydb.proto.federation.discovery";
 option java_outer_classname = "FederationDiscoveryProtos";
 
 import "protos/ydb_operation.proto";

--- a/protos/ydb_formats.proto
+++ b/protos/ydb_formats.proto
@@ -4,7 +4,7 @@ option cc_enable_arenas = true;
 package Ydb.Formats;
 
 option go_package = "github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Formats";
-option java_package = "tech.ydb.formats";
+option java_package = "tech.ydb.proto.formats";
 
 message ArrowBatchSettings {
     bytes schema = 1;

--- a/protos/ydb_import.proto
+++ b/protos/ydb_import.proto
@@ -9,7 +9,7 @@ import "google/protobuf/timestamp.proto";
 package Ydb.Import;
 
 option go_package = "github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Import";
-option java_package = "tech.ydb.import_";
+option java_package = "tech.ydb.proto.import_";
 
 /// Common
 message ImportProgress {

--- a/protos/ydb_issue_message.proto
+++ b/protos/ydb_issue_message.proto
@@ -4,7 +4,7 @@ option cc_enable_arenas = true;
 package Ydb.Issue;
 
 option go_package = "github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Issue";
-option java_package = "tech.ydb";
+option java_package = "tech.ydb.proto";
 
 // IssueMessage is a transport format for ydb/library/yql/public/issue library
 message IssueMessage {

--- a/protos/ydb_monitoring.proto
+++ b/protos/ydb_monitoring.proto
@@ -4,7 +4,7 @@ option cc_enable_arenas = true;
 package Ydb.Monitoring;
 
 option go_package = "github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Monitoring";
-option java_package = "tech.ydb.monitoring";
+option java_package = "tech.ydb.proto.monitoring";
 option java_outer_classname = "MonitoringProtos";
 
 import "protos/ydb_operation.proto";

--- a/protos/ydb_operation.proto
+++ b/protos/ydb_operation.proto
@@ -12,7 +12,7 @@ import "protos/ydb_status_codes.proto";
 package Ydb.Operations;
 
 option go_package = "github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Operations";
-option java_package = "tech.ydb";
+option java_package = "tech.ydb.proto";
 option java_outer_classname = "OperationProtos";
 
 message OperationParams {

--- a/protos/ydb_query_stats.proto
+++ b/protos/ydb_query_stats.proto
@@ -4,7 +4,7 @@ option cc_enable_arenas = true;
 package Ydb.TableStats;
 
 option go_package = "github.com/ydb-platform/ydb-go-genproto/protos/Ydb_TableStats";
-option java_package = "tech.ydb";
+option java_package = "tech.ydb.proto";
 
 // Describes select, update (insert, upsert, replace) and delete operations
 message OperationStats {

--- a/protos/ydb_rate_limiter.proto
+++ b/protos/ydb_rate_limiter.proto
@@ -4,7 +4,7 @@ option cc_enable_arenas = true;
 package Ydb.RateLimiter;
 
 option go_package = "github.com/ydb-platform/ydb-go-genproto/protos/Ydb_RateLimiter";
-option java_package = "tech.ydb.rate_limiter";
+option java_package = "tech.ydb.proto.rate_limiter";
 option java_outer_classname = "RateLimiterProtos";
 option java_multiple_files = true;
 

--- a/protos/ydb_scheme.proto
+++ b/protos/ydb_scheme.proto
@@ -4,7 +4,7 @@ option cc_enable_arenas = true;
 package Ydb.Scheme;
 
 option go_package = "github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Scheme";
-option java_package = "tech.ydb.scheme";
+option java_package = "tech.ydb.proto.scheme";
 option java_outer_classname = "SchemeOperationProtos";
 
 import "protos/ydb_common.proto";

--- a/protos/ydb_scripting.proto
+++ b/protos/ydb_scripting.proto
@@ -4,7 +4,7 @@ option cc_enable_arenas = true;
 package Ydb.Scripting;
 
 option go_package = "github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Scripting";
-option java_package = "tech.ydb.scripting";
+option java_package = "tech.ydb.proto.scripting";
 option java_outer_classname = "ScriptingProtos";
 
 import "protos/ydb_operation.proto";

--- a/protos/ydb_status_codes.proto
+++ b/protos/ydb_status_codes.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package Ydb;
 
 option go_package = "github.com/ydb-platform/ydb-go-genproto/protos/Ydb";
-option java_package = "tech.ydb";
+option java_package = "tech.ydb.proto";
 option java_outer_classname = "StatusCodesProtos";
 
 message StatusIds {

--- a/protos/ydb_table.proto
+++ b/protos/ydb_table.proto
@@ -18,7 +18,7 @@ import "google/protobuf/timestamp.proto";
 package Ydb.Table;
 
 option go_package = "github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Table";
-option java_package = "tech.ydb.table";
+option java_package = "tech.ydb.proto.table";
 
 // Create new session
 message CreateSessionRequest {

--- a/protos/ydb_topic.proto
+++ b/protos/ydb_topic.proto
@@ -12,7 +12,7 @@ import "google/protobuf/timestamp.proto";
 package Ydb.Topic;
 
 option go_package = "github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Topic";
-option java_package = "tech.ydb.topic";
+option java_package = "tech.ydb.proto.topic";
 
 option cc_enable_arenas = true;
 

--- a/protos/ydb_value.proto
+++ b/protos/ydb_value.proto
@@ -6,7 +6,7 @@ import "google/protobuf/struct.proto";
 package Ydb;
 
 option go_package = "github.com/ydb-platform/ydb-go-genproto/protos/Ydb";
-option java_package = "tech.ydb";
+option java_package = "tech.ydb.proto";
 option java_outer_classname = "ValueProtos";
 
 message DecimalType {

--- a/ydb_auth_v1.proto
+++ b/ydb_auth_v1.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package Ydb.Auth.V1;
 
 option go_package = "github.com/ydb-platform/ydb-go-genproto/Ydb_Auth_V1";
-option java_package = "tech.ydb.auth.v1";
+option java_package = "tech.ydb.proto.auth.v1";
 
 import "protos/ydb_auth.proto";
 

--- a/ydb_cms_v1.proto
+++ b/ydb_cms_v1.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package Ydb.Cms.V1;
 
 option go_package = "github.com/ydb-platform/ydb-go-genproto/Ydb_Cms_V1";
-option java_package = "tech.ydb.cms.v1";
+option java_package = "tech.ydb.proto.cms.v1";
 
 import "protos/ydb_cms.proto";
 

--- a/ydb_coordination_v1.proto
+++ b/ydb_coordination_v1.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package Ydb.Coordination.V1;
 
 option go_package = "github.com/ydb-platform/ydb-go-genproto/Ydb_Coordination_V1";
-option java_package = "tech.ydb.coordination.v1";
+option java_package = "tech.ydb.proto.coordination.v1";
 option java_outer_classname = "CoordinationGrpc";
 option java_multiple_files = true;
 

--- a/ydb_discovery_v1.proto
+++ b/ydb_discovery_v1.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package Ydb.Discovery.V1;
 
 option go_package = "github.com/ydb-platform/ydb-go-genproto/Ydb_Discovery_V1";
-option java_package = "tech.ydb.discovery.v1";
+option java_package = "tech.ydb.proto.discovery.v1";
 
 import "protos/ydb_discovery.proto";
 

--- a/ydb_export_v1.proto
+++ b/ydb_export_v1.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package Ydb.Export.V1;
 
 option go_package = "github.com/ydb-platform/ydb-go-genproto/Ydb_Export_V1";
-option java_package = "tech.ydb.export.v1";
+option java_package = "tech.ydb.proto.export.v1";
 
 import "protos/ydb_export.proto";
 

--- a/ydb_federation_discovery_v1.proto
+++ b/ydb_federation_discovery_v1.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package Ydb.FederationDiscovery.V1;
 
 option go_package = "github.com/ydb-platform/ydb-go-genproto/Ydb_FederationDiscovery_V1";
-option java_package = "tech.ydb.federation.discovery.v1";
+option java_package = "tech.ydb.proto.federation.discovery.v1";
 
 import "protos/ydb_federation_discovery.proto";
 

--- a/ydb_import_v1.proto
+++ b/ydb_import_v1.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package Ydb.Import.V1;
 
 option go_package = "github.com/ydb-platform/ydb-go-genproto/Ydb_Import_V1";
-option java_package = "tech.ydb.import_.v1";
+option java_package = "tech.ydb.proto.import_.v1";
 
 import "protos/ydb_import.proto";
 

--- a/ydb_monitoring_v1.proto
+++ b/ydb_monitoring_v1.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package Ydb.Monitoring.V1;
 
 option go_package = "github.com/ydb-platform/ydb-go-genproto/Ydb_Monitoring_V1";
-option java_package = "tech.ydb.monitoring.v1";
+option java_package = "tech.ydb.proto.monitoring.v1";
 
 import "protos/ydb_monitoring.proto";
 

--- a/ydb_operation_v1.proto
+++ b/ydb_operation_v1.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package Ydb.Operation.V1;
 
 option go_package = "github.com/ydb-platform/ydb-go-genproto/Ydb_Operation_V1";
-option java_package = "tech.ydb.operation.v1";
+option java_package = "tech.ydb.proto.operation.v1";
 
 import "protos/ydb_operation.proto";
 

--- a/ydb_rate_limiter_v1.proto
+++ b/ydb_rate_limiter_v1.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package Ydb.RateLimiter.V1;
 
 option go_package = "github.com/ydb-platform/ydb-go-genproto/Ydb_RateLimiter_V1";
-option java_package = "tech.ydb.rate_limiter.v1";
+option java_package = "tech.ydb.proto.rate_limiter.v1";
 option java_outer_classname = "RateLimiterGrpc";
 option java_multiple_files = true;
 

--- a/ydb_scheme_v1.proto
+++ b/ydb_scheme_v1.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package Ydb.Scheme.V1;
 
 option go_package = "github.com/ydb-platform/ydb-go-genproto/Ydb_Scheme_V1";
-option java_package = "tech.ydb.scheme.v1";
+option java_package = "tech.ydb.proto.scheme.v1";
 
 import "protos/ydb_scheme.proto";
 

--- a/ydb_scripting_v1.proto
+++ b/ydb_scripting_v1.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package Ydb.Scripting.V1;
 
 option go_package = "github.com/ydb-platform/ydb-go-genproto/Ydb_Scripting_V1";
-option java_package = "tech.ydb.scripting.v1";
+option java_package = "tech.ydb.proto.scripting.v1";
 
 import "protos/ydb_scripting.proto";
 

--- a/ydb_table_v1.proto
+++ b/ydb_table_v1.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package Ydb.Table.V1;
 
 option go_package = "github.com/ydb-platform/ydb-go-genproto/Ydb_Table_V1";
-option java_package = "tech.ydb.table.v1";
+option java_package = "tech.ydb.proto.table.v1";
 
 import "protos/ydb_table.proto";
 

--- a/ydb_topic_v1.proto
+++ b/ydb_topic_v1.proto
@@ -4,7 +4,7 @@ option cc_enable_arenas = true;
 package Ydb.Topic.V1;
 
 option go_package = "github.com/ydb-platform/ydb-go-genproto/Ydb_Topic_V1";
-option java_package = "tech.ydb.topic.v1";
+option java_package = "tech.ydb.proto.topic.v1";
 
 import "protos/ydb_topic.proto";
 


### PR DESCRIPTION
Move all proto classes to separate package tech.ydb.proto in order to divide SDK's classes for gen-proto classes