### PR TITLE
feat: add start_time to maintenance draft

### DIFF
--- a/draft/protos/ydb_maintenance.proto
+++ b/draft/protos/ydb_maintenance.proto
@@ -42,6 +42,8 @@ message Node {
         StorageNode storage = 6;
         DynamicNode dynamic = 7;
     }
+    // start_time defines time when node was registered in cms.
+    google.protobuf.Timestamp start_time = 8;
 }
 
 message ListClusterNodesRequest {


### PR DESCRIPTION
@shmel1k recently [added start_time property](https://github.com/ydb-platform/ydb/pull/2472/files#diff-74c4d09461763acf408be538ac933ee39090c9aaca91a498de79d69fc0bae4bf) to Public Maintenance Api. I need to use that in ydb-go-genproto, so I bring it here first.