### PR TITLE
feat: add version field to maintenance draft

### DIFF
--- a/draft/protos/ydb_maintenance.proto
+++ b/draft/protos/ydb_maintenance.proto
@@ -44,6 +44,9 @@ message Node {
     }
     // start_time defines time when node was registered in cms.
     google.protobuf.Timestamp start_time = 8;
+    // version defines YDB version for current Node.
+    // For example, 'ydb-stable-24-1'.
+    string version = 9;
 }
 
 message ListClusterNodesRequest {


### PR DESCRIPTION
This field has already been merged in trunk and stable-24-1: https://github.com/ydb-platform/ydb/pull/2796. It is required in rolling restart which uses ydb-go-genproto.