### PR TITLE
feat: add secret API protos

### DIFF
--- a/protos/ydb_scheme.proto
+++ b/protos/ydb_scheme.proto
@@ -69,6 +69,7 @@ message Entry {
         RESOURCE_POOL = 21;
         TRANSFER = 23;
         SYS_VIEW = 24;
+        SECRET = 25;
     }
 
     // Name of scheme entry (dir2 of /dir1/dir2)

--- a/protos/ydb_secret.proto
+++ b/protos/ydb_secret.proto
@@ -1,0 +1,34 @@
+syntax = "proto3";
+option cc_enable_arenas = true;
+
+package Ydb.Secret;
+
+option go_package = "github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Secret";
+option java_package = "tech.ydb.proto.secret";
+
+import "protos/annotations/validation.proto";
+import "protos/ydb_operation.proto";
+import "protos/ydb_scheme.proto";
+
+// Describe secret request sent from client to server.
+message DescribeSecretRequest {
+    Ydb.Operations.OperationParams operation_params = 1;
+
+    // Secret path
+    string path = 2;
+}
+
+// Describe secret response sent from server to client.
+// If the secret does not exist then response status will be "SCHEME_ERROR".
+message DescribeSecretResponse {
+    Ydb.Operations.Operation operation = 1;
+}
+
+// Describe secret result message that will be inside DescribeSecretResponse.operation.
+message DescribeSecretResult {
+    // Description of scheme object.
+    Ydb.Scheme.Entry self = 1;
+
+    // Internal version of the secret object
+    int64 version = 2 [(Ydb.value) = ">= 0"];
+}

--- a/ydb_secret_v1.proto
+++ b/ydb_secret_v1.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package Ydb.Secret.V1;
+
+option go_package = "github.com/ydb-platform/ydb-go-genproto/Ydb_Secret_V1";
+option java_package = "tech.ydb.proto.secret.v1";
+
+import "protos/ydb_secret.proto";
+
+service SecretService {
+    // Describe secret command.
+    rpc DescribeSecret(Secret.DescribeSecretRequest) returns (Secret.DescribeSecretResponse);
+}


### PR DESCRIPTION
Adds the secret service protos, synced from upstream `ydb-platform/ydb`.

- `protos/ydb_secret.proto` — `DescribeSecretRequest` / `DescribeSecretResponse` / `DescribeSecretResult`
- `ydb_secret_v1.proto` — `SecretService.DescribeSecret`
- `protos/ydb_scheme.proto` — `SECRET = 25` in `Entry.Type`

Adapted to this repo's conventions: `protos/...` import paths, `go_package`, `java_package`.

## Sources

- https://github.com/ydb-platform/ydb/blob/main/ydb/public/api/protos/ydb_secret.proto
- https://github.com/ydb-platform/ydb/blob/main/ydb/public/api/grpc/ydb_secret_v1.proto
- https://github.com/ydb-platform/ydb/blob/main/ydb/public/api/protos/ydb_scheme.proto
- Server + CLI/C++ SDK support: https://github.com/ydb-platform/ydb/commit/5e7bb5100364d450246698063289f10e645ecc62

Requested by https://github.com/ydb-platform/ydb-python-sdk/issues/866

## Notes

- Upstream renumbered `SECRET` from 27 to 25 in the commit above (adding `STREAMING_QUERY = 26`). This type was never declared here, so it is not a break for this repo.
- `Entry.Type` here is still missing upstream's `BACKUP_COLLECTION = 22` and `STREAMING_QUERY = 26` — left out of this PR.